### PR TITLE
Use new package style for emacs-pgtk-native-comp

### DIFF
--- a/flat/packages/emacs.scm
+++ b/flat/packages/emacs.scm
@@ -40,63 +40,63 @@
   (lambda* (emacs gcc #:optional full-aot)
     (let ((libgccjit (libgccjit-for-gcc gcc)))
       (package
-	(inherit emacs)
-	(source
-	 (origin
-	   (inherit (package-source emacs))
-	   (patches
-	    (append (search-patches "emacs-native-comp-exec-path.patch")
-		    (filter
-		     (lambda (f)
-		       (not (any (cut string-match <> f)
-				 '("/emacs-exec-path\\.patch$"
-				   "/emacs-ignore-empty-xim-styles\\.patch$"))))
-		     (origin-patches (package-source emacs)))))))
-	(arguments
-	 (substitute-keyword-arguments (package-arguments emacs)
-	   ((#:make-flags flags ''())
-	    (if full-aot
-		#~(cons* "NATIVE_FULL_AOT=1" #$flags)
-		flags))
-	   ((#:configure-flags flags)
-	    #~(cons* "--with-native-compilation" #$flags))
-	   ((#:phases phases)
-	    #~(modify-phases #$phases
-		;; Add build-time library paths for libgccjit.
-		(add-before 'configure 'set-libgccjit-path
-		  (lambda* (#:key inputs #:allow-other-keys)
-		    (let ((libgccjit-libdir
-			   (string-append (assoc-ref inputs "libgccjit")
-					  "/lib/gcc/" %host-type "/"
-					  #$(package-version libgccjit) "/")))
-		      (setenv "LIBRARY_PATH"
-			      (string-append libgccjit-libdir ":"
-					     (getenv "LIBRARY_PATH"))))
-		    #t))
-		;; Add runtime library paths for libgccjit.
-		(add-after 'unpack 'patch-driver-options
-		  (lambda* (#:key inputs #:allow-other-keys)
-		    (substitute* "lisp/emacs-lisp/comp.el"
-		      (("\\(defcustom native-comp-driver-options nil")
-		       (format
-			#f "(defcustom native-comp-driver-options '(~s ~s ~s ~s)"
-			(string-append
-			 "-B" (assoc-ref inputs "binutils") "/bin/")
-			(string-append
-			 "-B" (assoc-ref inputs "glibc") "/lib/")
-			(string-append
-			 "-B" (assoc-ref inputs "libgccjit") "/lib/")
-			(string-append
-			 "-B" (assoc-ref inputs "libgccjit") "/lib/gcc/"))))
-		    #t))))))
-	(native-inputs
-	 (modify-inputs (package-native-inputs emacs)
-			(prepend gcc)))
-	(inputs
-	 (modify-inputs (package-inputs emacs)
-			(prepend glibc
-				 libgccjit
-				 libxcomposite))))))) ;; FIXME belongs upstream
+        (inherit emacs)
+        (source
+         (origin
+           (inherit (package-source emacs))
+           (patches
+            (append (search-patches "emacs-native-comp-exec-path.patch")
+                    (filter
+                     (lambda (f)
+                       (not (any (cut string-match <> f)
+                                 '("/emacs-exec-path\\.patch$"
+                                   "/emacs-ignore-empty-xim-styles\\.patch$"))))
+                     (origin-patches (package-source emacs)))))))
+        (arguments
+         (substitute-keyword-arguments (package-arguments emacs)
+           ((#:make-flags flags ''())
+            (if full-aot
+                #~(cons* "NATIVE_FULL_AOT=1" #$flags)
+                flags))
+           ((#:configure-flags flags)
+            #~(cons* "--with-native-compilation" #$flags))
+           ((#:phases phases)
+            #~(modify-phases #$phases
+                ;; Add build-time library paths for libgccjit.
+                (add-before 'configure 'set-libgccjit-path
+                  (lambda* (#:key inputs #:allow-other-keys)
+                    (let ((libgccjit-libdir
+                           (string-append (assoc-ref inputs "libgccjit")
+                                          "/lib/gcc/" %host-type "/"
+                                          #$(package-version libgccjit) "/")))
+                      (setenv "LIBRARY_PATH"
+                              (string-append libgccjit-libdir ":"
+                                             (getenv "LIBRARY_PATH"))))
+                    #t))
+                ;; Add runtime library paths for libgccjit.
+                (add-after 'unpack 'patch-driver-options
+                  (lambda* (#:key inputs #:allow-other-keys)
+                    (substitute* "lisp/emacs-lisp/comp.el"
+                      (("\\(defcustom native-comp-driver-options nil")
+                       (format
+                        #f "(defcustom native-comp-driver-options '(~s ~s ~s ~s)"
+                        (string-append
+                         "-B" (assoc-ref inputs "binutils") "/bin/")
+                        (string-append
+                         "-B" (assoc-ref inputs "glibc") "/lib/")
+                        (string-append
+                         "-B" (assoc-ref inputs "libgccjit") "/lib/")
+                        (string-append
+                         "-B" (assoc-ref inputs "libgccjit") "/lib/gcc/"))))
+                    #t))))))
+        (native-inputs
+         (modify-inputs (package-native-inputs emacs)
+                        (prepend gcc)))
+        (inputs
+         (modify-inputs (package-inputs emacs)
+                        (prepend glibc
+                                 libgccjit
+                                 libxcomposite))))))) ;; FIXME belongs upstream
 
 (define emacs-from-git
   (lambda* (emacs #:key pkg-name pkg-version pkg-revision git-repo git-commit checksum)
@@ -106,13 +106,13 @@
       (version (git-version pkg-version pkg-revision git-commit))
       (source
        (origin
-	 (inherit (package-source emacs))
-	 (method git-fetch)
-	 (uri (git-reference
-	       (url git-repo)
-	       (commit git-commit)))
-	 (sha256 (base32 checksum))
-	 (file-name (git-file-name pkg-name pkg-version))))
+         (inherit (package-source emacs))
+         (method git-fetch)
+         (uri (git-reference
+               (url git-repo)
+               (commit git-commit)))
+         (sha256 (base32 checksum))
+         (file-name (git-file-name pkg-name pkg-version))))
       (outputs
        '("out" "debug")))))
 
@@ -122,7 +122,7 @@
    #:pkg-name "emacs-native-comp"
    #:pkg-version "28.1.50"
    #:pkg-revision "200"
-   ;#:git-repo "https://git.savannah.gnu.org/git/emacs.git"
+                                        ;#:git-repo "https://git.savannah.gnu.org/git/emacs.git"
    #:git-repo "https://github.com/emacs-mirror/emacs.git"
    #:git-commit "3b6338c8c351cce721f2f1aa115cadc401179d5c"
    #:checksum "1h7b5l1549mxf0s6knl5jcrji65ld0zph6yq8pfpgizagmkp4mfd"))

--- a/flat/packages/emacs.scm
+++ b/flat/packages/emacs.scm
@@ -122,7 +122,7 @@
    #:pkg-name "emacs-native-comp"
    #:pkg-version "28.1.50"
    #:pkg-revision "200"
-                                        ;#:git-repo "https://git.savannah.gnu.org/git/emacs.git"
+   ;#:git-repo "https://git.savannah.gnu.org/git/emacs.git"
    #:git-repo "https://github.com/emacs-mirror/emacs.git"
    #:git-commit "3b6338c8c351cce721f2f1aa115cadc401179d5c"
    #:checksum "1h7b5l1549mxf0s6knl5jcrji65ld0zph6yq8pfpgizagmkp4mfd"))


### PR DESCRIPTION
A recent change upstream (https://issues.guix.gnu.org/issue/55419) involving packages moving to the new package definition style (https://guix.gnu.org/blog/2021/the-big-change/) broke emacs-pgtk-native-comp. 

This fixes that by adapting emacs-pgtk-native-comp to the new style as well.

Sorry about the slightly messy commit history, but I figured you'd squash the history in case this gets merged anyway.

Fixes #18