### PR TITLE
Moved out of the patching fuzz range

### DIFF
--- a/flat/packages/patches/emacs-native-comp-exec-path.patch
+++ b/flat/packages/patches/emacs-native-comp-exec-path.patch
@@ -4,7 +4,7 @@ with things like GCC being referenced.
 
 --- a/lisp/loadup.el
 +++ b/lisp/loadup.el
-@@ -526,7 +526,8 @@
+@@ -545,7 +545,8 @@
                          ((equal dump-mode "dump") "emacs")
                          ((equal dump-mode "bootstrap") "emacs")
                          ((equal dump-mode "pbootstrap") "bootstrap-emacs.pdmp")


### PR DESCRIPTION
`loadup.el` seems to have had material added ahead of the existing patch. This should be appropriate as of today.